### PR TITLE
fix: use package.json from @arkecosystem/core  for CLI

### DIFF
--- a/src/service-provider.ts
+++ b/src/service-provider.ts
@@ -55,7 +55,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
             this.app.bind(Identifiers.CliManager).to(CliManager).inSingletonScope();
             this.app.bind(Identifiers.WorkerManager).to(WorkerManager).inSingletonScope();
 
-            const pkg: Types.PackageJson = require("../package.json");
+            const pkg: Types.PackageJson = require("@arkecosystem/core/package.json");
             this.app.bind(Identifiers.CLI).toConstantValue(ApplicationFactory.make(new Container.Container(), pkg));
         }
     }


### PR DESCRIPTION
## Summary

Use package.json from @arkecosystem/core for CLI. This fix update issues. Latest version is compared to @arkecosystem/core  instead @arkecosystem/core-manager.

## Checklist

- [x] Ready to be merged