### PR TITLE
fix: accept password with spaces

### DIFF
--- a/__tests__/utils/cli-manager.test.ts
+++ b/__tests__/utils/cli-manager.test.ts
@@ -52,10 +52,18 @@ describe("CliManager", () => {
     });
 
     it("should run command with a password that uses spaces", async () => {
-        await cliManager.runCommand("command_name", "--network:testnet --token=ark --password=with spaces");
+        await cliManager.runCommand("command_name", "--network:testnet --token=ark --password='with spaces'");
 
         expect(mockCommand.register).toHaveBeenCalledTimes(1);
         expect(mockCommand.register).toHaveBeenCalledWith(["command_name", "--network:testnet", "--token=ark", "--password=with spaces"]);
+        expect(mockCommand.run).toHaveBeenCalledTimes(1);
+    });
+
+    it("should run command with a password that ends with a space", async () => {
+        await cliManager.runCommand("command_name", "--network:testnet --token=ark --password='with_a_space_at_end '");
+
+        expect(mockCommand.register).toHaveBeenCalledTimes(1);
+        expect(mockCommand.register).toHaveBeenCalledWith(["command_name", "--network:testnet", "--token=ark", "--password=with_a_space_at_end "]);
         expect(mockCommand.run).toHaveBeenCalledTimes(1);
     });
 

--- a/__tests__/utils/cli-manager.test.ts
+++ b/__tests__/utils/cli-manager.test.ts
@@ -67,7 +67,7 @@ describe("CliManager", () => {
         expect(mockCommand.run).toHaveBeenCalledTimes(1);
     });
 
-    it("should run command with a password that contains a double quite", async () => {
+    it("should run command with a password that contains a double quote", async () => {
         await cliManager.runCommand("command_name", '--network:testnet --token=ark --password=\'with"doubleQuote\'');
 
         expect(mockCommand.register).toHaveBeenCalledTimes(1);
@@ -80,6 +80,14 @@ describe("CliManager", () => {
 
         expect(mockCommand.register).toHaveBeenCalledTimes(1);
         expect(mockCommand.register).toHaveBeenCalledWith(["command_name", "--network:testnet", "--token=ark", "--password=with'quote"]);
+        expect(mockCommand.run).toHaveBeenCalledTimes(1);
+    });
+
+    it("should run command with a password that contains an backslash", async () => {
+        await cliManager.runCommand("command_name", "--network:testnet --token=ark --password='with\\backslash'");
+
+        expect(mockCommand.register).toHaveBeenCalledTimes(1);
+        expect(mockCommand.register).toHaveBeenCalledWith(["command_name", "--network:testnet", "--token=ark", '--password=with\\backslash']);
         expect(mockCommand.run).toHaveBeenCalledTimes(1);
     });
 

--- a/__tests__/utils/cli-manager.test.ts
+++ b/__tests__/utils/cli-manager.test.ts
@@ -83,7 +83,7 @@ describe("CliManager", () => {
         expect(mockCommand.run).toHaveBeenCalledTimes(1);
     });
 
-    it("should run command with a password that contains an backslash", async () => {
+    it("should run command with a password that contains a backslash", async () => {
         await cliManager.runCommand("command_name", "--network:testnet --token=ark --password='with\\backslash'");
 
         expect(mockCommand.register).toHaveBeenCalledTimes(1);

--- a/__tests__/utils/cli-manager.test.ts
+++ b/__tests__/utils/cli-manager.test.ts
@@ -51,6 +51,14 @@ describe("CliManager", () => {
         expect(mockCommand.run).toHaveBeenCalledTimes(1);
     });
 
+    it("should run command with a password that uses spaces", async () => {
+        await cliManager.runCommand("command_name", "--network:testnet --token=ark --password=with spaces");
+
+        expect(mockCommand.register).toHaveBeenCalledTimes(1);
+        expect(mockCommand.register).toHaveBeenCalledWith(["command_name", "--network:testnet", "--token=ark", "--password=with spaces"]);
+        expect(mockCommand.run).toHaveBeenCalledTimes(1);
+    });
+
     it("should throw if command does not exist", async () => {
         await expect(cliManager.runCommand("invalid_command_name")).rejects.toThrow(
             "Command invalid_command_name does not exists.",

--- a/__tests__/utils/cli-manager.test.ts
+++ b/__tests__/utils/cli-manager.test.ts
@@ -67,6 +67,14 @@ describe("CliManager", () => {
         expect(mockCommand.run).toHaveBeenCalledTimes(1);
     });
 
+    it("should run command with a password that contains an escaped quote", async () => {
+        await cliManager.runCommand("command_name", '--network:testnet --token=ark --password=\'with\\\'quote\'');
+
+        expect(mockCommand.register).toHaveBeenCalledTimes(1);
+        expect(mockCommand.register).toHaveBeenCalledWith(["command_name", "--network:testnet", "--token=ark", "--password=with'quote"]);
+        expect(mockCommand.run).toHaveBeenCalledTimes(1);
+    });
+
     it("should throw if command does not exist", async () => {
         await expect(cliManager.runCommand("invalid_command_name")).rejects.toThrow(
             "Command invalid_command_name does not exists.",

--- a/__tests__/utils/cli-manager.test.ts
+++ b/__tests__/utils/cli-manager.test.ts
@@ -67,6 +67,14 @@ describe("CliManager", () => {
         expect(mockCommand.run).toHaveBeenCalledTimes(1);
     });
 
+    it("should run command with a password that contains a double quite", async () => {
+        await cliManager.runCommand("command_name", '--network:testnet --token=ark --password=\'with"doubleQuote\'');
+
+        expect(mockCommand.register).toHaveBeenCalledTimes(1);
+        expect(mockCommand.register).toHaveBeenCalledWith(["command_name", "--network:testnet", "--token=ark", '--password=with"doubleQuote']);
+        expect(mockCommand.run).toHaveBeenCalledTimes(1);
+    });
+
     it("should run command with a password that contains an escaped quote", async () => {
         await cliManager.runCommand("command_name", '--network:testnet --token=ark --password=\'with\\\'quote\'');
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "latest-version": "^5.1.0",
         "lodash.clonedeep": "^4.5.0",
         "public-ip": "^4.0.3",
+        "string-to-argv": "^1.0.0",
         "systeminformation": "^5.6.20",
         "typeorm": "0.2.25"
     },

--- a/src/utils/cli-manager.ts
+++ b/src/utils/cli-manager.ts
@@ -1,7 +1,8 @@
 import * as Cli from "@arkecosystem/core-cli";
 import { Container } from "@arkecosystem/core-kernel";
-import { Identifiers } from "../ioc";
 import { dirname, join } from "path";
+
+import { Identifiers } from "../ioc";
 
 @Container.injectable()
 export class CliManager {
@@ -17,13 +18,38 @@ export class CliManager {
             throw new Error(`Command ${name} does not exists.`);
         }
 
-        const splitArgs = args.replace(/\s+/g, " ").split(" ");
+        const parsedArguments = this.parseArguments(args);
 
-        const argv = [name, ...splitArgs];
+        const argv = [name, ...parsedArguments];
 
         command.register(argv);
 
         await command.run();
+    }
+
+    private parseArguments(args: string): string[] {
+        // Look for:
+        // - <param>: everything that start with -- and ends with an space or `=`
+        // - <value> (optional) everything after the '=' until find a space
+        // - OR <quotedValue> (optional) everything after the '=' that is between quotes "'"
+        const regex = /(?<param>--[^\s|=]*)=?(?:(?:'(?<quotedValue>[^']*)')|(?<value>[^\s]*))/gm;
+
+        const parsedArguments: string[] = [];
+
+        let match: RegExpExecArray | null;
+        while ((match = regex.exec(args)) !== null) {
+            if (match.groups === undefined) {
+                continue;
+            }
+
+            const { param, quotedValue, value } = match.groups;
+
+            const argParts = [param, quotedValue || value].filter(Boolean);
+
+            parsedArguments.push(argParts.join("="));
+        }
+
+        return parsedArguments.length ? parsedArguments : [""];
     }
 
     private discoverCommands(): Cli.Contracts.CommandList {

--- a/src/utils/cli-manager.ts
+++ b/src/utils/cli-manager.ts
@@ -31,8 +31,8 @@ export class CliManager {
         // Look for:
         // - <param>: everything that start with -- and ends with an space or `=`
         // - <value> (optional) everything after the '=' until find a space
-        // - OR <quotedValue> (optional) everything after the '=' that is between quotes "'"
-        const regex = /(?<param>--[^\s|=]*)=?(?:(?:'(?<quotedValue>[^']*)')|(?<value>[^\s]*))/gm;
+        // - OR <quotedValue> (optional) everything after the '=' that is between quotes "'" (excluding escaped ones)
+        const regex = /(?<param>--[^\s|=]*)=?(?:(?:'(?<quotedValue>(?:(?:\\')|[^'])*)')|(?<value>[^\s]*))/gm;
 
         const parsedArguments: string[] = [];
 
@@ -44,7 +44,13 @@ export class CliManager {
 
             const { param, quotedValue, value } = match.groups;
 
-            const argParts = [param, quotedValue || value].filter(Boolean);
+            let escapedQuotedValue: string | undefined = undefined;
+
+            if (quotedValue) {
+                escapedQuotedValue = quotedValue.replace(/\\'/g, "'");
+            }
+
+            const argParts = [param, escapedQuotedValue || value].filter(Boolean);
 
             parsedArguments.push(argParts.join("="));
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13837,6 +13837,11 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
+string-to-argv@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/string-to-argv/-/string-to-argv-1.0.0.tgz#b45eb19c808ba6231d1c63169e7325d5879de297"
+  integrity sha512-nr0PF3/gvxMGiP8XmRGWs8DEJkK/b+dcHi8Mscs5ruuCrgKXQjE0rhSCWOwNYQBjgDedr4wXEpSOwf1M/JiG3Q==
+
 string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/1j481w7

Currently, if I send a password with space through the API `--pasword=with spaces` the password  is splitted into two different arguments (see test)

This PR refactors the cli manager to allow quoted parameters so we can send something like --password='with spaces', also considers the case where the users sent an escaped quote 

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
