### PR TITLE
fix: get randomNodeHeight from node

### DIFF
--- a/__tests__/actions/info-blockchain-height.test.ts
+++ b/__tests__/actions/info-blockchain-height.test.ts
@@ -3,43 +3,33 @@ import "jest-extended";
 import { Action } from "../../src/actions/info-blockchain-height";
 import { HttpClient } from "../../src/utils/http-client";
 import { Sandbox } from "@arkecosystem/core-test-framework";
+import cloneDeep from "lodash.clonedeep";
 
 let sandbox: Sandbox;
 let action: Action;
 
-let mockPeers;
-
-beforeEach(() => {
-    mockPeers = [
+const mockPeersResponse = {
+    data: [
         {
             ip: "0.0.0.0",
-            height: 10,
+            ports: {
+                "@arkecosystem/core-api": 4003,
+            }
         },
-    ];
+    ]
+}
+const mockStatusResponse = {
+    data: {
+        now: 10
+    }
+}
 
-    HttpClient.prototype.get = jest.fn().mockImplementation(async (path: string) => {
-        if (path === "/api/blockchain") {
-            return {
-                data: {
-                    block: {
-                        height: 10,
-                    },
-                },
-            };
-        }
-
-        // /api/peers
-        return {
-            data: mockPeers,
-        };
-    });
-
+beforeEach(() => {
     sandbox = new Sandbox();
     action = sandbox.app.resolve(Action);
 });
 
 afterEach(() => {
-    delete process.env.CORE_API_DISABLED;
     jest.clearAllMocks();
 });
 
@@ -49,18 +39,65 @@ describe("Info:BlockchainHeight", () => {
     });
 
     it("should return height and random node height", async () => {
+        jest.spyOn(HttpClient.prototype, "get")
+            .mockResolvedValueOnce(mockStatusResponse)
+            .mockResolvedValueOnce(mockPeersResponse)
+            .mockResolvedValueOnce(mockStatusResponse)
+
         const result = await action.execute({});
 
         expect(result).toEqual({ height: 10, randomNodeHeight: 10, randomNodeIp: "0.0.0.0" });
     });
 
-    it("should return only height if no peers found", async () => {
-        mockPeers = [];
+    it("should throw /get/status on host throws", async () => {
+        jest.spyOn(HttpClient.prototype, "get")
+            .mockImplementation(async () => {
+                throw new Error("dummy");
+            })
+
+        await expect(action.execute({})).rejects.toThrowError("dummy");
+    })
+
+    it("should return only height if no peers with enabled api", async () => {
+        const tmpMockPeersResponse = cloneDeep(mockPeersResponse)
+        tmpMockPeersResponse.data[0].ports["@arkecosystem/core-api"] = -1
+
+        jest.spyOn(HttpClient.prototype, "get")
+            .mockResolvedValueOnce(mockStatusResponse)
+            .mockResolvedValueOnce(tmpMockPeersResponse)
 
         const result = await action.execute({});
 
         expect(result).toEqual({ height: 10 });
         expect(result.randomNodeHeight).toBeUndefined();
         expect(result.randomNodeIp).toBeUndefined();
+    });
+
+    it("should return only height if /api/peers/ throws", async () => {
+        jest.spyOn(HttpClient.prototype, "get")
+            .mockResolvedValueOnce(mockStatusResponse)
+            .mockImplementation(async () => {
+                throw new Error("dummy");
+            })
+
+        const result = await action.execute({});
+
+        expect(result).toEqual({ height: 10 });
+        expect(result.randomNodeHeight).toBeUndefined();
+        expect(result.randomNodeIp).toBeUndefined();
+    });
+
+    it("should try to call peer 3 times", async () => {
+        const spyOnGet = jest.spyOn(HttpClient.prototype, "get")
+            .mockResolvedValueOnce(mockStatusResponse)
+            .mockResolvedValueOnce(mockPeersResponse)
+            .mockImplementation(async () => {
+                throw new Error("dummy");
+            })
+
+        const result = await action.execute({});
+
+        expect(result).toEqual({ height: 10 });
+        expect(spyOnGet).toHaveBeenCalledTimes(5);
     });
 });


### PR DESCRIPTION
## Summary

Update **info.blockchainHeight** to retrieve `randomNodeHeight` directly from peer. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged