### PR TITLE
reafactor: throw ERR_NO_RELAY

### DIFF
--- a/__tests__/actions/info-blockchain-height.test.ts
+++ b/__tests__/actions/info-blockchain-height.test.ts
@@ -49,13 +49,13 @@ describe("Info:BlockchainHeight", () => {
         expect(result).toEqual({ height: 10, randomNodeHeight: 10, randomNodeIp: "0.0.0.0" });
     });
 
-    it("should throw /get/status on host throws", async () => {
+    it("should throw ERR_NO_RELAY if host no response from host", async () => {
         jest.spyOn(HttpClient.prototype, "get")
             .mockImplementation(async () => {
                 throw new Error("dummy");
             })
 
-        await expect(action.execute({})).rejects.toThrowError("dummy");
+        await expect(action.execute({})).rejects.toThrowError("ERR_NO_RELAY");
     })
 
     it("should return only height if no peers with enabled api", async () => {
@@ -73,18 +73,14 @@ describe("Info:BlockchainHeight", () => {
         expect(result.randomNodeIp).toBeUndefined();
     });
 
-    it("should return only height if /api/peers/ throws", async () => {
+    it("should return ERR_NO_RELAY height if /api/peers/ throws", async () => {
         jest.spyOn(HttpClient.prototype, "get")
             .mockResolvedValueOnce(mockStatusResponse)
             .mockImplementation(async () => {
                 throw new Error("dummy");
             })
 
-        const result = await action.execute({});
-
-        expect(result).toEqual({ height: 10 });
-        expect(result.randomNodeHeight).toBeUndefined();
-        expect(result.randomNodeIp).toBeUndefined();
+        await expect(action.execute({})).rejects.toThrowError("ERR_NO_RELAY");
     });
 
     it("should try to call peer 3 times", async () => {

--- a/src/actions/info-blockchain-height.ts
+++ b/src/actions/info-blockchain-height.ts
@@ -9,9 +9,15 @@ export class Action implements Actions.Action {
     public name = "info.blockchainHeight";
 
     public async execute(params: any): Promise<any> {
-        let response = {
-            height: await this.getHeight(Utils.getConnectionData()),
-        };
+        let response = {};
+
+        try {
+            response = {
+                height: await this.getHeight(Utils.getConnectionData()),
+            }
+        } catch {
+            throw new Error("ERR_NO_RELAY");
+        }
 
         try {
             response = {

--- a/src/actions/info-blockchain-height.ts
+++ b/src/actions/info-blockchain-height.ts
@@ -10,11 +10,14 @@ export class Action implements Actions.Action {
 
     public async execute(params: any): Promise<any> {
         let response = {};
+        let peers: ConnectionData[];
 
         try {
             response = {
                 height: await this.getHeight(Utils.getConnectionData()),
             }
+
+            peers = await this.getPeers();
         } catch {
             throw new Error("ERR_NO_RELAY");
         }
@@ -22,7 +25,7 @@ export class Action implements Actions.Action {
         try {
             response = {
                 ...response,
-                ...(await this.prepareRandomNodeHeight()),
+                ...(await this.prepareRandomNodeHeight(peers)),
             };
         } catch {}
 
@@ -42,7 +45,7 @@ export class Action implements Actions.Action {
 
         const response = await httpClient.get("/api/peers");
 
-        const peers = response.data
+        return response.data
             .map((peer) => {
                 return {
                     ip: peer.ip,
@@ -51,16 +54,12 @@ export class Action implements Actions.Action {
                 };
             })
             .filter((peer: ConnectionData) => peer.port && peer.port > 0);
+    }
 
+    private async prepareRandomNodeHeight(peers: ConnectionData[]): Promise<{ randomNodeHeight: number; randomNodeIp: string }> {
         if (!peers.length) {
             throw new Error("No peers found.");
         }
-
-        return peers;
-    }
-
-    private async prepareRandomNodeHeight(): Promise<{ randomNodeHeight: number; randomNodeIp: string }> {
-        const peers = await this.getPeers();
 
         for(let i = 0; i < 3; i++) {
             const peer = peers[Math.floor(Math.random() * peers.length)];


### PR DESCRIPTION
## Summary

Throw jsonrpc error with message: ERR_NO_RELAY when core-manager cannot connect to the host.  

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged
