### PR TITLE
fix: use `--skipPrompts` in command flags  

### DIFF
--- a/src/actions/info-blockchain-height.ts
+++ b/src/actions/info-blockchain-height.ts
@@ -9,9 +9,15 @@ export class Action implements Actions.Action {
     public name = "info.blockchainHeight";
 
     public async execute(params: any): Promise<any> {
-        let response = {
-            height: await this.getHeight(Utils.getConnectionData()),
-        };
+        let response = {};
+
+        try {
+            response = {
+                height: await this.getHeight(Utils.getConnectionData()),
+            }
+        } catch {
+            throw new Error("ERR_NO_RELAY");
+        }
 
         try {
             response = {

--- a/src/utils/cli-manager.ts
+++ b/src/utils/cli-manager.ts
@@ -21,9 +21,7 @@ export class CliManager {
 
         const argv = parseArgvString(args);
 
-        if (argv.length === 0) {
-            argv.push("");
-        }
+        argv.push("--skipPrompts=true");
 
         argv.unshift(name);
 


### PR DESCRIPTION
## Summary

Use `--skipPrompts` in command flags to prevent processes to become stuck on cli prompts.   

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged
