### PR TITLE
fix: use --skipPrompts in command flags

### DIFF
--- a/__tests__/utils/cli-manager.test.ts
+++ b/__tests__/utils/cli-manager.test.ts
@@ -39,7 +39,7 @@ describe("CliManager", () => {
         await cliManager.runCommand("command_name");
 
         expect(mockCommand.register).toHaveBeenCalledTimes(1);
-        expect(mockCommand.register).toHaveBeenCalledWith(["command_name", ""]);
+        expect(mockCommand.register).toHaveBeenCalledWith(["command_name", "--skipPrompts=true"]);
         expect(mockCommand.run).toHaveBeenCalledTimes(1);
     });
 
@@ -47,7 +47,7 @@ describe("CliManager", () => {
         await cliManager.runCommand("command_name", "--network:testnet --token=ark");
 
         expect(mockCommand.register).toHaveBeenCalledTimes(1);
-        expect(mockCommand.register).toHaveBeenCalledWith(["command_name", "--network:testnet", "--token=ark"]);
+        expect(mockCommand.register).toHaveBeenCalledWith(["command_name", "--network:testnet", "--token=ark", "--skipPrompts=true"]);
         expect(mockCommand.run).toHaveBeenCalledTimes(1);
     });
 
@@ -55,7 +55,7 @@ describe("CliManager", () => {
         await cliManager.runCommand("command_name", "--network:testnet --token=ark --password='with spaces'");
 
         expect(mockCommand.register).toHaveBeenCalledTimes(1);
-        expect(mockCommand.register).toHaveBeenCalledWith(["command_name", "--network:testnet", "--token=ark", "--password=with spaces"]);
+        expect(mockCommand.register).toHaveBeenCalledWith(["command_name", "--network:testnet", "--token=ark", "--password=with spaces", "--skipPrompts=true"]);
         expect(mockCommand.run).toHaveBeenCalledTimes(1);
     });
 
@@ -63,7 +63,7 @@ describe("CliManager", () => {
         await cliManager.runCommand("command_name", "--network:testnet --token=ark --password='with_a_space_at_end '");
 
         expect(mockCommand.register).toHaveBeenCalledTimes(1);
-        expect(mockCommand.register).toHaveBeenCalledWith(["command_name", "--network:testnet", "--token=ark", "--password=with_a_space_at_end "]);
+        expect(mockCommand.register).toHaveBeenCalledWith(["command_name", "--network:testnet", "--token=ark", "--password=with_a_space_at_end ", "--skipPrompts=true"]);
         expect(mockCommand.run).toHaveBeenCalledTimes(1);
     });
 
@@ -71,7 +71,7 @@ describe("CliManager", () => {
         await cliManager.runCommand("command_name", '--network:testnet --token=ark --password=\'with"doubleQuote\'');
 
         expect(mockCommand.register).toHaveBeenCalledTimes(1);
-        expect(mockCommand.register).toHaveBeenCalledWith(["command_name", "--network:testnet", "--token=ark", '--password=with"doubleQuote']);
+        expect(mockCommand.register).toHaveBeenCalledWith(["command_name", "--network:testnet", "--token=ark", '--password=with"doubleQuote', "--skipPrompts=true"]);
         expect(mockCommand.run).toHaveBeenCalledTimes(1);
     });
 
@@ -79,7 +79,7 @@ describe("CliManager", () => {
         await cliManager.runCommand("command_name", '--network:testnet --token=ark --password=\'with\\\'quote\'');
 
         expect(mockCommand.register).toHaveBeenCalledTimes(1);
-        expect(mockCommand.register).toHaveBeenCalledWith(["command_name", "--network:testnet", "--token=ark", "--password=with'quote"]);
+        expect(mockCommand.register).toHaveBeenCalledWith(["command_name", "--network:testnet", "--token=ark", "--password=with'quote", "--skipPrompts=true"]);
         expect(mockCommand.run).toHaveBeenCalledTimes(1);
     });
 
@@ -87,7 +87,7 @@ describe("CliManager", () => {
         await cliManager.runCommand("command_name", "--network:testnet --token=ark --password='with\\backslash'");
 
         expect(mockCommand.register).toHaveBeenCalledTimes(1);
-        expect(mockCommand.register).toHaveBeenCalledWith(["command_name", "--network:testnet", "--token=ark", '--password=with\\backslash']);
+        expect(mockCommand.register).toHaveBeenCalledWith(["command_name", "--network:testnet", "--token=ark", '--password=with\\backslash', "--skipPrompts=true"]);
         expect(mockCommand.run).toHaveBeenCalledTimes(1);
     });
 

--- a/src/utils/cli-manager.ts
+++ b/src/utils/cli-manager.ts
@@ -21,9 +21,7 @@ export class CliManager {
 
         const argv = parseArgvString(args);
 
-        if (argv.length === 0) {
-            argv.push("");
-        }
+        argv.push("--skipPrompts=true");
 
         argv.unshift(name);
 


### PR DESCRIPTION
## Summary

Use `--skipPrompts` in command flags to prevent processes to become stuck on cli prompts.   

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged