### PR TITLE
fix: determine current version from running process

### DIFF
--- a/__tests__/actions/info-core-version.test.ts
+++ b/__tests__/actions/info-core-version.test.ts
@@ -5,6 +5,7 @@ import { Container } from "@arkecosystem/core-kernel";
 import { Action } from "../../src/actions/info-core-version";
 import { Identifiers } from "../../src/ioc";
 import {readJSONSync} from "fs-extra";
+import * as Cli from "@arkecosystem/core-cli";
 
 jest.mock("fs-extra", () => {
     return {
@@ -19,8 +20,14 @@ const mockCliConfig = {
     get: jest.fn().mockReturnValue("next"),
 };
 
+const mockProcessManager = {
+    list: jest.fn().mockReturnValue([]),
+    status: jest.fn().mockReturnValue(Cli.Contracts.ProcessState.Online)
+};
+
 const mockCli = {
     resolve: jest.fn().mockReturnValue(mockCliConfig),
+    get: jest.fn().mockReturnValue(mockProcessManager),
 };
 
 beforeEach(() => {
@@ -38,7 +45,7 @@ describe("Info:CoreVersion", () => {
         expect(action.name).toEqual("info.coreVersion");
     });
 
-    it("should return current and latest version", async () => {
+    it("should return versions", async () => {
         readJSONSync
             .mockReturnValueOnce({ version: "3.0.0" }) // core-kernel
             .mockReturnValueOnce({ version: "3.0.2" }); // core-manager
@@ -49,7 +56,69 @@ describe("Info:CoreVersion", () => {
 
         const result = await promise;
 
-        await expect(result.currentVersion).toBe("3.0.0");
+        await expect(result.currentVersion).toBe(undefined);
+        await expect(result.installedVersion).toBe("3.0.0");
+        await expect(result.latestVersion).toBeString();
+        await expect(result.manager.currentVersion).toBe("3.0.1");
+        await expect(result.manager.installedVersion).toBe("3.0.2");
+        await expect(result.manager.latestVersion).toBeString();
+    }, 10000);
+
+    it("should return current relay version", async () => {
+        mockProcessManager.list.mockReturnValue([
+            {
+                name: "ark-relay",
+                pm2_env: {
+                    version: "4.0.0"
+                }
+            }
+        ])
+
+        readJSONSync
+            .mockReturnValueOnce({ version: "3.0.0" }) // core-kernel
+            .mockReturnValueOnce({ version: "3.0.2" }); // core-manager
+
+        const promise = action.execute({});
+
+        await expect(promise).toResolve();
+
+        const result = await promise;
+
+        await expect(result.currentVersion).toBe("4.0.0");
+        await expect(result.installedVersion).toBe("3.0.0");
+        await expect(result.latestVersion).toBeString();
+        await expect(result.manager.currentVersion).toBe("3.0.1");
+        await expect(result.manager.installedVersion).toBe("3.0.2");
+        await expect(result.manager.latestVersion).toBeString();
+    }, 10000);
+
+    it("should return current core version", async () => {
+        mockProcessManager.list.mockReturnValue([
+            {
+                name: "ark-core",
+                pm2_env: {
+                    version: "4.0.1"
+                }
+            },
+            {
+                name: "ark-relay",
+                pm2_env: {
+                    version: "4.0.0"
+                }
+            }
+        ])
+
+        readJSONSync
+            .mockReturnValueOnce({ version: "3.0.0" }) // core-kernel
+            .mockReturnValueOnce({ version: "3.0.2" }); // core-manager
+
+        const promise = action.execute({});
+
+        await expect(promise).toResolve();
+
+        const result = await promise;
+
+        await expect(result.currentVersion).toBe("4.0.1");
         await expect(result.installedVersion).toBe("3.0.0");
         await expect(result.latestVersion).toBeString();
         await expect(result.manager.currentVersion).toBe("3.0.1");

--- a/__tests__/actions/process-list.test.ts
+++ b/__tests__/actions/process-list.test.ts
@@ -17,7 +17,9 @@ beforeEach(() => {
         pid: 13477,
         name: "ark-manager",
         pm_id: 0,
-        pm2_env: {},
+        pm2_env: {
+            version: "4.0.0-next.2"
+        },
         monit: {
             memory: 98283520,
             cpu: 0.1,
@@ -68,6 +70,7 @@ describe("Process:List", () => {
                     memory: 95980,
                     cpu: 0.1,
                 },
+                version: "4.0.0-next.2",
                 status: "online",
             },
         ]);
@@ -91,6 +94,7 @@ describe("Process:List", () => {
                     memory: 95980,
                     cpu: 0.1,
                 },
+                version: "4.0.0-next.2",
                 status: "undefined",
             },
         ]);

--- a/src/actions/process-list.ts
+++ b/src/actions/process-list.ts
@@ -23,6 +23,8 @@ export class Action implements Actions.Action {
         const processList = processManager.list();
 
         for (const processInfo of processList) {
+            processInfo.version = processInfo.pm2_env.version;
+
             delete processInfo.pm2_env;
 
             processInfo.monit.memory = Math.round(processInfo.monit.memory / 1024);


### PR DESCRIPTION
## Summary

Determine current version of process from pm2. 

`process.list` include new property **version**.

`info.coreVersion` determines **currentVersion** from `core` or `relay` process. **currentVersion** is now optional. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged