### PR TITLE
fix: skip branch check on publish

### DIFF
--- a/.github/workflows/cd-develop.yml
+++ b/.github/workflows/cd-develop.yml
@@ -27,6 +27,6 @@ jobs:
               run: pnpm run build
 
             - name: Publish to NPM
-              run: pnpm publish --access=public --tag=next
+              run: pnpm publish --access=public --tag=next --git-checks=false
               env:
                   NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/cd-master.yml
+++ b/.github/workflows/cd-master.yml
@@ -27,6 +27,6 @@ jobs:
               run: yarn build
 
             - name: Publish to NPM
-              run: pnpm publish --access=public
+              run: pnpm publish --access=public --git-checks=false
               env:
                   NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
## Summary

Skip branch check on publish. This allows publishing from develop branch. 

## Checklist

- [x] Ready to be merged
