### PR TITLE
refactor: use --skipVersionCheck in command flags

### DIFF
--- a/__tests__/utils/cli-manager.test.ts
+++ b/__tests__/utils/cli-manager.test.ts
@@ -40,7 +40,11 @@ describe("CliManager", () => {
         await cliManager.runCommand("command_name");
 
         expect(mockCommand.register).toHaveBeenCalledTimes(1);
-        expect(mockCommand.register).toHaveBeenCalledWith(["command_name", "--skipPrompts=true"]);
+        expect(mockCommand.register).toHaveBeenCalledWith([
+            "command_name",
+            "--skipPrompts=true",
+            "--skipVersionCheck=true",
+        ]);
         expect(mockCommand.run).toHaveBeenCalledTimes(1);
     });
 
@@ -53,6 +57,7 @@ describe("CliManager", () => {
             "--network:testnet",
             "--token=ark",
             "--skipPrompts=true",
+            "--skipVersionCheck=true",
         ]);
         expect(mockCommand.run).toHaveBeenCalledTimes(1);
     });
@@ -67,6 +72,7 @@ describe("CliManager", () => {
             "--token=ark",
             "--password=with spaces",
             "--skipPrompts=true",
+            "--skipVersionCheck=true",
         ]);
         expect(mockCommand.run).toHaveBeenCalledTimes(1);
     });
@@ -81,6 +87,7 @@ describe("CliManager", () => {
             "--token=ark",
             "--password=with_a_space_at_end ",
             "--skipPrompts=true",
+            "--skipVersionCheck=true",
         ]);
         expect(mockCommand.run).toHaveBeenCalledTimes(1);
     });
@@ -95,6 +102,7 @@ describe("CliManager", () => {
             "--token=ark",
             '--password=with"doubleQuote',
             "--skipPrompts=true",
+            "--skipVersionCheck=true",
         ]);
         expect(mockCommand.run).toHaveBeenCalledTimes(1);
     });
@@ -109,6 +117,7 @@ describe("CliManager", () => {
             "--token=ark",
             "--password=with'quote",
             "--skipPrompts=true",
+            "--skipVersionCheck=true",
         ]);
         expect(mockCommand.run).toHaveBeenCalledTimes(1);
     });
@@ -123,6 +132,7 @@ describe("CliManager", () => {
             "--token=ark",
             "--password=with\\backslash",
             "--skipPrompts=true",
+            "--skipVersionCheck=true",
         ]);
         expect(mockCommand.run).toHaveBeenCalledTimes(1);
     });

--- a/src/utils/cli-manager.ts
+++ b/src/utils/cli-manager.ts
@@ -22,6 +22,7 @@ export class CliManager {
         const argv = parseArgvString(args);
 
         argv.push("--skipPrompts=true");
+        argv.push("--skipVersionCheck=true");
 
         argv.unshift(name);
 


### PR DESCRIPTION
## Summary

Use `--skipVersionCheck` in command flags to prevent version checks. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged