### PR TITLE
chore: use pnpm in scripts

### DIFF
--- a/.github/workflows/cd-master.yml
+++ b/.github/workflows/cd-master.yml
@@ -24,7 +24,7 @@ jobs:
                     run_install: true
 
             - name: Build
-              run: yarn build
+              run: pnpm run build
 
             - name: Publish to NPM
               run: pnpm publish --access=public --git-checks=false

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "main": "dist/index",
     "types": "dist/index",
     "scripts": {
-        "build": "yarn clean && yarn compile",
-        "build:watch": "yarn clean && yarn compile -w",
+        "build": "pnpm run clean && pnpm run compile",
+        "build:watch": "pnpm run clean && pnpm run compile -w",
         "build:docs": "node_modules/typedoc/bin/typedoc --out docs src",
         "clean": "rimraf dist",
         "compile": "node node_modules/typescript/bin/tsc",
@@ -21,7 +21,7 @@
         "lint:fix": "eslint src --ext .ts --fix",
         "lint:tests": "eslint __tests__ --ext .ts --max-warnings 0",
         "lint:tests:fix": "eslint __tests__ --ext .ts --fix",
-        "prepublishOnly": "yarn build",
+        "prepublishOnly": "pnpm run build",
         "test": "jest"
     },
     "dependencies": {


### PR DESCRIPTION
## Summary

- Use pnpm in package.json scripts. 
- Use pnpm on master CI

## Checklist

- [x] Ready to be merged

