### PR TITLE
feat: add restart prameter to `info.coreUpdate`

### DIFF
--- a/__tests__/actions/info-core-update.test.ts
+++ b/__tests__/actions/info-core-update.test.ts
@@ -36,4 +36,11 @@ describe("Info:CoreUpdate", () => {
         expect(result).toEqual({});
         expect(mockCliManager.runCommand).toHaveBeenCalledWith("update", "--force");
     });
+
+    it("should call start process with --restart flag", async () => {
+        const result = await action.execute({ restart: true });
+
+        expect(result).toEqual({});
+        expect(mockCliManager.runCommand).toHaveBeenCalledWith("update", "--force --restart");
+    });
 });

--- a/src/actions/info-core-update.ts
+++ b/src/actions/info-core-update.ts
@@ -11,8 +11,23 @@ export class Action implements Actions.Action {
 
     public name = "info.coreUpdate";
 
-    public async execute(params: object): Promise<any> {
-        await this.cliManager.runCommand("update", "--force");
+    public schema = {
+        type: "object",
+        properties: {
+            restart: {
+                type: "boolean",
+            },
+        },
+    };
+
+    public async execute(params: { restart?: boolean }): Promise<any> {
+        let args = "--force";
+
+        if (params.restart) {
+            args += " --restart";
+        }
+
+        await this.cliManager.runCommand("update", args);
         return {};
     }
 }


### PR DESCRIPTION
## Summary

Add **restart** parameter to `info.coreUpdate`, which calls update command with --restart flag when parameter is truthy. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged
